### PR TITLE
Avoid page reload on share clicked, if the Vue router in history mode

### DIFF
--- a/src/share-network.js
+++ b/src/share-network.js
@@ -187,7 +187,7 @@ export default {
       }
     }
 
-    if (this.tag === 'a') node.attrs = { href: '#' }
+    if (this.tag === 'a') node.attrs = { href: 'javascript:void(0)' }
 
     return createElement(this.tag, node, this.$slots.default)
   },


### PR DESCRIPTION
avoid page reload on share clicked, if the Vue router in `history` mode